### PR TITLE
fix: 🐛 make the Runner.runRecursive method asynchronous

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -310,7 +310,7 @@ export class Runner {
           !hasScript || c.children.some((c) => c.type == CommandType.script)
       )
     command.concurrent = true
-    this._run(command, -1)
+    return this._run(command, -1)
 
     // process.exit(1)
   }


### PR DESCRIPTION
I try to use `Runner` API to create tasks queue, but `runRecursive` don't work with async/await as expected. This fix allow using `runRecursive` in this case like `run` method.