### PR TITLE
fix: Consistency in displaying

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -195,7 +195,7 @@ export class Runner {
       console.log(
         `${chalk.bgGray.cyanBright(` ${counter++} `)} ${chalk.green(
           `${p.name}`
-        )} at ./${chalk.whiteBright(relative(workspace.root, p.root))}`
+        )} at ${chalk.whiteBright(relative(workspace.root, p.root))}`
       )
       Object.keys(p.scripts || {})
         .sort()


### PR DESCRIPTION
On win environment the `--list` outputs : 
```
project at ./packages\ui
```
Which is wrong because it would be `.\packages\ui`
Other commands like spawning outputs
```
project at packages\ui
```

If you want to keep `./` or `.\` we need to use `require("path").delimiter` but it's a bit useless IMO