### PR TITLE
fix: 🐛 resolution in pnp subpackages

### DIFF
--- a/src/pnp.ts
+++ b/src/pnp.ts
@@ -54,7 +54,7 @@ export function getBinaries(workspaceRoot: string, packageName: string) {
           const binPath = resolveRequest(
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             path.join(pkgName, p.bin.get(b)!),
-            process.cwd()
+            path.resolve(process.cwd(), "package.json")
           )
           binaries.set(b, binPath)
           // eslint-disable-next-line no-empty


### PR DESCRIPTION
`resolveRequest` second argument requires a file path and not a directory, 

Previously commands from sub packages would silently throw `Your application tried to access module not listed in your dependencies` because of this