### PR TITLE
fix(git): 🐛 .ultraignore considered in getGitFiles

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -36,8 +36,12 @@ export function parseFiles(data: string, root: string): GitFiles {
 
 export async function getGitFiles(root: string): Promise<GitFiles> {
   return new Promise((resolve, reject) => {
+    const gitIgnoreExists = fs.existsSync(path.resolve(root, ".gitignore"))
+    const lsFiles = `git ls-files --full-name -s -d -c -m -o ${
+      gitIgnoreExists ? "-X .gitignore" : ""
+    } --directory -t`
     exec(
-      "git ls-files --full-name -s -d -c -m -o --directory -t",
+      lsFiles,
       { cwd: root, maxBuffer: 1024 * 1024 * 1024 },
       (error, stdout) => {
         if (error) return reject(error)

--- a/src/git.ts
+++ b/src/git.ts
@@ -36,9 +36,9 @@ export function parseFiles(data: string, root: string): GitFiles {
 
 export async function getGitFiles(root: string): Promise<GitFiles> {
   return new Promise((resolve, reject) => {
-    const gitIgnoreExists = fs.existsSync(path.resolve(root, ".gitignore"))
+    const ultraIgnoreExists = fs.existsSync(path.resolve(root, ".ultraignore"))
     const lsFiles = `git ls-files --full-name -s -d -c -m -o ${
-      gitIgnoreExists ? "-X .gitignore" : ""
+      ultraIgnoreExists ? "-X .ultraignore" : ""
     } --directory -t`
     exec(
       lsFiles,


### PR DESCRIPTION
this PR fixes #117 by excluding patterns in .ultraignore (if exists)