### PR TITLE
fix(ultraignore): allow ultraignore to work with tracked git files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ stats.html
 tsconfig.build.tsbuildinfo
 .ultra.cache.json
 .nyc_output
+.idea

--- a/.ultraignore
+++ b/.ultraignore
@@ -1,0 +1,2 @@
+# Used only for cache unit tests
+__tests__/**/file-to-ignore.js

--- a/__tests__/git.ts
+++ b/__tests__/git.ts
@@ -41,15 +41,19 @@ test("getGitFiles", async () => {
   expect(files["__tests__/workspace/apps/app2/package.json"]).toMatch(
     /^[a-z0-9]*$/u
   )
+  expect(files["__tests__/workspace/apps/app1/file-to-ignore.js"]).toMatch(
+    /^[a-z0-9]*$/u
+  )
   expect(files[""]).toMatch(/^\d+\.\d+$/u)
 
-  expect(Object.keys(files)).toHaveLength(3)
+  expect(Object.keys(files)).toHaveLength(4)
 })
 
 test("cache", async () => {
   const files = f(await cache.getFiles(path.resolve(workspaceRoot, "apps")))
   expect(files["app1/package.json"]).toMatch(/^[a-z0-9]*$/u)
   expect(files["app2/package.json"]).toMatch(/^[a-z0-9]*$/u)
+  expect(files["app1/file-to-ignore.js"]).toBeUndefined()
   expect(Object.keys(files)).toHaveLength(2)
   expect(cache.cache.size).not.toBe(0)
   await cache.getFiles(path.resolve(workspaceRoot, "apps"))

--- a/__tests__/workspace/apps/app1/file-to-ignore.js
+++ b/__tests__/workspace/apps/app1/file-to-ignore.js
@@ -1,0 +1,1 @@
+export const FOO = 'foo'

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "cross-spawn": "^7.0.3",
     "fast-glob": "^3.2.5",
     "globrex": "^0.1.2",
+    "ignore": "^5.1.8",
     "json5": "^2.2.0",
     "micro-memoize": "^4.0.9",
     "npm-run-path": "4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ dependencies:
   cross-spawn: 7.0.3
   fast-glob: 3.2.5
   globrex: 0.1.2
+  ignore: 5.1.8
   json5: 2.2.0
   micro-memoize: 4.0.9
   npm-run-path: 4.0.1
@@ -4312,7 +4313,6 @@ packages:
     resolution:
       integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
   /ignore/5.1.8:
-    dev: true
     engines:
       node: '>= 4'
     resolution:
@@ -8921,6 +8921,7 @@ specifiers:
   fast-glob: ^3.2.5
   globrex: ^0.1.2
   husky: 5.1.1
+  ignore: ^5.1.8
   jest: 26.6.3
   json5: ^2.2.0
   markdownlint-cli: 0.26.0


### PR DESCRIPTION
When trying out the new `.ultraignore` feature, I found a bug where you could not ignore files tracked by git.

After looking into this, it is because the `git ls-files -X <file>` does not work for files being tracked in git. In my case, I wanted to ignore `jest.config.js` as well as test files under `src/`.

This PR uses the popular [node-ignore](https://www.npmjs.com/package/ignore) package to parse the `.ultraignore` file and excludes its entries directly at the cache level.

Note that I have a failing test on my machine. This was failing before making my change, and I think it is environment-specific. Maybe I am on a newer version of `npx` than the one these tests were written with?

<img src="https://user-images.githubusercontent.com/5550247/109370547-63b90800-7866-11eb-899f-b1842f596e86.png" width="500" />

I did add a test for the new `.ultraignore` behavior.