### PR TITLE
fix: npe when using yarn workspaces with lerna

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -56,7 +56,7 @@ export class Workspace {
     const types = Object.entries(providers)
     for (const [type, provider] of types) {
       if (["single", "recursive"].includes(type)) continue
-      if ((await provider(cwd))?.patterns.length) {
+      if ((await provider(cwd))?.patterns?.length) {
         ret.push(type as WorkspaceProviderType)
       }
     }


### PR DESCRIPTION
Some projects use lerna and yarn workspaces. When using yarn workspaces there may not be patterns in lerna configuration, this causes the patterns to NPE when running ultra --info