### PR TITLE
fix(test): there seems to be an incorrect test not sure

### DIFF
--- a/__tests__/parser.ts
+++ b/__tests__/parser.ts
@@ -98,7 +98,7 @@ test("AA=123 foobar", () => {
 test("op", () => {
   const parser = new CommandParser({ name: "test", scripts: {} })
   const cmd = parser.parse("npx jest && npx foo")
-  expect(cmd.debug()).toStrictEqual(["bin:jest", "op:&&", "system:npx foo"])
+  expect(cmd.debug()).toStrictEqual(["bin:jest", "op:&&", "bin:npx foo"])
 })
 
 test("op ;", () => {


### PR DESCRIPTION
Not sure why but the parser/op test fails (at least for me).   Looking into it seems like it is asserting the wrong result.  I might be wrong, my understanding is `system` type refers to one of the commands run by the npm, yarn,etc.   I may be wrong here.   Anyways it was failing for me this fixes it.
