### PR TITLE
feat: allow multiple filters

### DIFF
--- a/__tests__/filter.ts
+++ b/__tests__/filter.ts
@@ -8,7 +8,7 @@ test("filter dir", async () => {
   expect(workspace).toBeDefined()
   if (workspace) {
     const dirs = workspace
-      .getPackages("apps/*")
+      .getPackages(["apps/*"])
       .map((p) =>
         path.relative("__tests__/workspace", p.root).replace(/\\/gu, "/")
       )
@@ -25,7 +25,7 @@ test("filter pkg", async () => {
   expect(workspace).toBeDefined()
   if (workspace) {
     const dirs = workspace
-      .getPackages("@scoped/*")
+      .getPackages(["@scoped/*"])
       .map((p) =>
         path.relative("__tests__/workspace", p.root).replace(/\\/gu, "/")
       )
@@ -42,7 +42,7 @@ test("filter pkg no deps", async () => {
   expect(workspace).toBeDefined()
   if (workspace) {
     const dirs = workspace
-      .getPackages("*app1")
+      .getPackages(["*app1"])
       .map((p) =>
         path.relative("__tests__/workspace", p.root).replace(/\\/gu, "/")
       )
@@ -59,12 +59,29 @@ test("filter pkg with deps", async () => {
   expect(workspace).toBeDefined()
   if (workspace) {
     const dirs = workspace
-      .getPackages("+*app1")
+      .getPackages(["+*app1"])
       .map((p) =>
         path.relative("__tests__/workspace", p.root).replace(/\\/gu, "/")
       )
     dirs.sort()
     // eslint-disable-next-line jest/no-conditional-expect
     expect(dirs).toStrictEqual(["apps/app1", "libs/lib1", "libs/lib2"])
+  }
+})
+
+test("filter multiple apps", async () => {
+  const workspace = await ws.getWorkspace({
+    cwd: "__tests__/workspace/apps/app1",
+  })
+  expect(workspace).toBeDefined()
+  if (workspace) {
+    const dirs = workspace
+      .getPackages(["*/lib1", "*/lib2"])
+      .map((p) =>
+        path.relative("__tests__/workspace", p.root).replace(/\\/gu, "/")
+      )
+    dirs.sort()
+    // eslint-disable-next-line jest/no-conditional-expect
+    expect(dirs).toStrictEqual(["libs/lib1", "libs/lib2"])
   }
 })

--- a/__tests__/options.ts
+++ b/__tests__/options.ts
@@ -1,5 +1,10 @@
-import { defaults } from "../src/options"
+import { defaults, parse } from "../src/options"
 
 test("should", () => {
   expect(defaults).toBeDefined()
+})
+
+test("should parse array options correctly", () => {
+  const options = parse(["", "", "--filter", "a", "--filter", "b"])
+  expect(options.filter).toEqual(["a", "b"])
 })

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,7 +6,7 @@ export const HASH_FILE = ".ultra.cache.json"
 
 export const defaults = {
   recursive: false,
-  filter: undefined as string | undefined,
+  filter: [] as string[],
   color: chalk.supportsColor !== undefined,
   pretty: process.stdout.isTTY,
   raw: false,
@@ -29,7 +29,7 @@ export const defaults = {
 export type RunnerOptions = typeof defaults
 
 type RunnerOptionDef = {
-  type: "number" | "boolean" | "string"
+  type: "number" | "boolean" | "string" | "array"
   description: string
   hidden?: boolean
   alias?: string
@@ -67,7 +67,7 @@ export const RunnerOptionDefs: Record<keyof RunnerOptions, RunnerOptionDef> = {
       "Set the maximum number of concurrency to 1. Same as --concurrency 1",
   },
   filter: {
-    type: "string",
+    type: "array",
     description:
       "Filter package name or directory using wildcard pattern. Prefix the filter with '+' to always include dependencies.",
   },
@@ -148,6 +148,12 @@ export function parse(argv: string[] = process.argv) {
       } else if (def.type == "string") {
         // @ts-ignore
         ret[arg] = argv[++offset]
+      } else if (def.type == "array") {
+        // @ts-ignore
+        if (!ret[arg]) ret[arg] = []
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        ret[arg].push(argv[++offset])
       }
     } else unknown.push(arg)
   }


### PR DESCRIPTION
My first approach was trying to use [minimatch](https://www.npmjs.com/package/minimatch) instead of `globrex`. Minimatch allow patterns like `*/+(lib1|lib2)`. The problem with this syntax is that it could conflict with the syntax to include the dependencies. 

Finally, I decided to update the options parser to accept an array of filters.

Example:

```bash
ultra -r --filter "*/lib1" --filter "*/lib2" build
```


This feature was already requested on https://github.com/folke/ultra-runner/issues/182