### PR TITLE
Update README.md, list npm workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Commands are always run concurrently with a default concurrency of `10` (can be 
 
 **Ultra** finds packages based on your monorepo workspace:
 
+* npm
 * lerna
 * pnpm
 * yarn workspace


### PR DESCRIPTION
I gather from this,

https://github.com/folke/ultra-runner/blob/f8fcd3dc6ecbabd6c9629dba53fc3fcbe828133a/src/workspace.providers.ts#L26

that ultra-runner supports npm workspaces.