### PR TITLE
fix: windows echo command issues

### DIFF
--- a/__tests__/spawn.ts
+++ b/__tests__/spawn.ts
@@ -44,7 +44,13 @@ test("raw echo foo", async () => {
 })
 
 test("lines", async () => {
-  const spawner = new Spawner("echo", ["-n", "foo\nbar"])
+  // This needs to sit on two lines to support both
+  // windows and ubuntu tests
+  const spawner = new Spawner("echo", [
+    `foo
+     bar`,
+  ])
+
   spawner.onLine = sinon.fake()
   await spawner.spawn()
   chai.expect(spawner.onLine).to.be.calledTwice


### PR DESCRIPTION
I saw that the windows build was failing on `FAIL __tests__/spawn.ts ● lines`
I tracked this down to the `echo` command being used. Whilst the linux `echo` supports both `-n` and `\n`, windows does not. It seems the only way to create a new line with windows `echo` is by running to command again which doesn't really fit the test case. This solution however passes for both linux and windows and follows the lint rules.