### PR TITLE
fix(options): correct typo "seperate" → "separate" in --pretty description

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -101,7 +101,7 @@ export const RunnerOptionDefs: Record<keyof RunnerOptions, RunnerOptionDef> = {
   pretty: {
     type: "boolean",
     description:
-      "enable pretty output, spinners and seperate command output. Default when a TTY",
+      "enable pretty output, spinners and separate command output. Default when a TTY",
   },
   raw: { type: "boolean", description: "Output only raw command output" },
   silent: {


### PR DESCRIPTION
## Summary

Fixes a typo in the `--pretty` flag description in `src/options.ts`: \"seperate command output\" → \"separate command output\". This text is user-visible — it appears in the output of `ultra --help`.

No behavior change. Description-text only.